### PR TITLE
Add dotenv package.

### DIFF
--- a/elm-pages.config.mjs
+++ b/elm-pages.config.mjs
@@ -1,5 +1,7 @@
 import { defineConfig } from "vite";
 import adapter from "elm-pages/adapter/netlify.js";
+import { config } from 'dotenv';
+config();
 
 export default {
   vite: defineConfig({}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "elm-pages-app",
       "hasInstallScript": true,
       "dependencies": {
-        "@netlify/functions": "^1.4.0"
+        "@netlify/functions": "^1.4.0",
+        "dotenv": "^16.1.3"
       },
       "devDependencies": {
         "elm-codegen": "^0.3.0",
@@ -1246,6 +1247,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.3.tgz",
+      "integrity": "sha512-FYssxsmCTtKL72fGBSvb1K9dRz0/VZeWqFme/vSb7r7323x4CRaHu4LvQ5JG3+s6yt2YPbBrkpiEODktfyjI9A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/duplexer3": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "vite": "^4.3.5"
   },
   "dependencies": {
-    "@netlify/functions": "^1.4.0"
+    "@netlify/functions": "^1.4.0",
+    "dotenv": "^16.1.3"
   }
 }


### PR DESCRIPTION
Hey @dillonkearns.

I am not 100% sure if this is the best way to do this, but this worked for me to get the environment variables from my .env file into the elm-pages build.

Netlify environment variables worked already and this doesn't break that.